### PR TITLE
Model 4 artifact

### DIFF
--- a/src/vivarium_csu_alzheimers/constants/data_keys.py
+++ b/src/vivarium_csu_alzheimers/constants/data_keys.py
@@ -37,13 +37,19 @@ class __Alzheimers(NamedTuple):
     )
     # Prevalence will just be set to 1 so all simulants are created with the disease
     PREVALENCE: str = "cause.alzheimers_disease_and_other_dementias.prevalence"
+    PREVALENCE_ALL_STATES: str = "cause.alzheimers_all_states.prevalence"
+    BBBM_PREVALANCE: str = "cause.bbbm.prevalence"
+    MCI_PREVALENCE: str = "cause.mci.prevalence"
     INCIDENCE_RATE: str = "cause.alzheimers_disease_and_other_dementias.incidence_rate"
+    BBBM_INCIDENCE_RATE: str = "cause.bbbm.incidence_rate"
+    # MCI incidence rate caluclated during sim using mci_hazard.py and time in state
     TOTAL_POPULATION_INCIDENCE_RATE: str = (
         "cause.alzheimers_disease_and_other_dementias.population_incidence_rate"
     )
     CSMR: str = "cause.alzheimers_disease_and_other_dementias.cause_specific_mortality_rate"
     EMR: str = "cause.alzheimers_disease_and_other_dementias.excess_mortality_rate"
     DISABLIITY_WEIGHT: str = "cause.alzheimers_disease_and_other_dementias.disability_weight"
+    MCI_DISABILITY_WEIGHT: str = "caues.mci.disability_weight"
     RESTRICTIONS: str = "cause.alzheimers_disease_and_other_dementias.restrictions"
 
     @property

--- a/src/vivarium_csu_alzheimers/constants/data_keys.py
+++ b/src/vivarium_csu_alzheimers/constants/data_keys.py
@@ -17,6 +17,7 @@ class __Population(NamedTuple):
     TMRLE: str = "population.theoretical_minimum_risk_life_expectancy"
     ACMR: str = "cause.all_causes.cause_specific_mortality_rate"
     LIVE_BIRTH_RATE: str = "covariate.live_births_by_sex.estimate"
+    SCALING_FACTOR = str = "population.scaling_factor"
 
     @property
     def name(self):
@@ -31,24 +32,22 @@ POPULATION = __Population()
 
 
 class __Alzheimers(NamedTuple):
-    # Prevalence scale factor will scale the population and "fertility" of the model
-    PREVALENCE_SCALE_FACTOR: str = (
-        "cause.alzheimers_disease_and_other_dementias.prevalence_scale_factor"
-    )
-    # Prevalence will just be set to 1 so all simulants are created with the disease
     PREVALENCE: str = "cause.alzheimers_disease_and_other_dementias.prevalence"
-    PREVALENCE_ALL_STATES: str = "cause.alzheimers_all_states.prevalence"
-    BBBM_PREVALANCE: str = "cause.bbbm.prevalence"
-    MCI_PREVALENCE: str = "cause.mci.prevalence"
+    BBBM_CONDITIONAL_PREVALANCE: str = "cause.bbbm.prevalence"
+    MCI_CONDITIONAL_PREVALENCE: str = "cause.mci.prevalence"
     INCIDENCE_RATE: str = "cause.alzheimers_disease_and_other_dementias.incidence_rate"
     BBBM_INCIDENCE_RATE: str = "cause.bbbm.incidence_rate"
     # MCI incidence rate caluclated during sim using mci_hazard.py and time in state
     TOTAL_POPULATION_INCIDENCE_RATE: str = (
         "cause.alzheimers_disease_and_other_dementias.population_incidence_rate"
     )
-    CSMR: str = "cause.alzheimers_disease_and_other_dementias.cause_specific_mortality_rate"
+    CSMR: str = (
+        "cause.alzheimers_disease_and_other_dementias.cause_specific_mortality_rate"
+    )
     EMR: str = "cause.alzheimers_disease_and_other_dementias.excess_mortality_rate"
-    DISABLIITY_WEIGHT: str = "cause.alzheimers_disease_and_other_dementias.disability_weight"
+    DISABLIITY_WEIGHT: str = (
+        "cause.alzheimers_disease_and_other_dementias.disability_weight"
+    )
     MCI_DISABILITY_WEIGHT: str = "caues.mci.disability_weight"
     RESTRICTIONS: str = "cause.alzheimers_disease_and_other_dementias.restrictions"
 

--- a/src/vivarium_csu_alzheimers/constants/data_values.py
+++ b/src/vivarium_csu_alzheimers/constants/data_values.py
@@ -49,5 +49,5 @@ GAMMA_SCALE = 1 / rate
 GAMMA_DIST = scipy.stats.gamma(GAMMA_SHAPE, scale=GAMMA_SCALE)
 
 BBBM_AVG_DURATION = GAMMA_SHAPE / rate
-MCI_AVG_DURATION = 3.75  # from client
+MCI_AVG_DURATION = 3.25  # from client
 MCI_TO_AD_HAZARD = 0.25  # TBD, this is made up

--- a/src/vivarium_csu_alzheimers/constants/data_values.py
+++ b/src/vivarium_csu_alzheimers/constants/data_values.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import scipy
 
 ############################
 # Disease Model Parameters #
@@ -32,3 +33,21 @@ SCREENING_SCALE_UP_GOAL_COVERAGE = 0.50
 SCREENING_SCALE_UP_DIFFERENCE = (
     SCREENING_SCALE_UP_GOAL_COVERAGE - PROBABILITY_ATTENDING_SCREENING_START_MEAN
 )
+
+
+# Gamma distribution parameters from Abie's nb
+mean = 3.75  # Fix mean at midpoint of interval [3.5, 4]
+variance = 0.03  # Adjust variance until about 90% of probability lies in interval
+
+# Use method of moments to get shape and rate parameters
+GAMMA_SHAPE = mean**2 / variance  # shape parameter alpha
+rate = mean / variance  # rate parameter lambda
+
+# Convert rate to scale for scipy
+GAMMA_SCALE = 1 / rate
+
+GAMMA_DIST = scipy.stats.gamma(GAMMA_SHAPE, scale=GAMMA_SCALE)
+
+BBBM_AVG_DURATION = GAMMA_SHAPE / rate
+MCI_AVG_DURATION = 3.75  # from client
+MCI_TO_AD_HAZARD = 0.25  # TBD, this is made up

--- a/src/vivarium_csu_alzheimers/data/mci_hazard.py
+++ b/src/vivarium_csu_alzheimers/data/mci_hazard.py
@@ -1,0 +1,11 @@
+# copied from Nathaniel's notebook
+
+from vivarium_csu_alzheimers.constants.data_values import GAMMA_DIST
+
+
+def hazard(t, dist):
+    # hazard = (probability density) / (survival function)
+    return dist.pdf(t) / dist.sf(t)
+
+
+gamma_hazard = lambda t: hazard(t, GAMMA_DIST)


### PR DESCRIPTION
## Model 4 artifact
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: data artifact
- *JIRA issue*: https://jira.ihme.washington.edu/browse/SSCI-2387
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.html

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
- Adds new Alzheimers component keys and data for model 4
- Removes Alz prevalence scale factor, adds scaling factor key to Population component calculated as Alz all states prevalence per attention box equation 1

Open items:
- BBBM incidence math from Nathaniel
- MCI_TO_AD_HAZARD value (constant)
-  Abie suggested naming all keys that are for AD dementia state with "ALZHEIMERS.AD_DEMENTIA", such as ALZHEIMERS.AD_DEMENTIA_INCIDENCE_RATE" which is currently "ALZHEIMERS.PREVALENCE", but this is most of the keys and would make them pretty long. Note that for BBBM and MCI states, the keys are labelled this way to specify the state, eg "ALZHEIMERS.BBBM_INCIDENCE_RATE", while for AD dementia state the state is currently just implied by "ALZHEIMERS.".


### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

