### PR TITLE
Use MCMC to find consistent rates for the BBBM-AD model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.hdf
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/artifact_requirements.txt
+++ b/artifact_requirements.txt
@@ -18,3 +18,7 @@ black==22.3.0
 isort
 jupyterlab
 matplotlib
+jax
+numpyro
+diffrax
+interpax

--- a/src/vivarium_csu_alzheimers/data/consistent_rates.py
+++ b/src/vivarium_csu_alzheimers/data/consistent_rates.py
@@ -1,0 +1,448 @@
+"""NumPyro/JAX implementation of DisMod-AT, refactored from notebook 2024_07_28a_dismod_ipd_ai_refactor.ipynb
+"""
+from typing import Callable
+
+import interpax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpyro
+import pandas as pd
+from diffrax import Dopri5, ODETerm, SaveAt, diffeqsolve
+from numpyro import distributions as dist
+from numpyro import infer
+from vivarium import Artifact
+
+def transform_to_data(param, df_in, sex, ages, years):
+    """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
+    t = df_in.loc[sex]
+    results = []  # fill with rows of data, then convert to a dataframe
+
+    for a in ages:
+        for y in years:
+            row = {
+                "age_start": a,
+                "age_end": a,
+                "year_start": y,
+                "year_end": y,
+                "sex": sex,
+                "measure": param,
+            }
+            tt = t.query(
+                "age_start <= @a and @a < age_end and year_start <= @y and @y < year_end"
+            )
+            assert len(tt) == 1
+            row["mean"] = np.mean(tt.iloc[0])
+            row["standard_error"] = (
+                np.std(tt.iloc[0])
+                + 0.00000001  # add a little bit to the s2 for everything, just to avoid zeros
+            )
+
+            results.append(row)
+
+    return pd.DataFrame(results)
+
+
+def transform_to_prior(df, sex, ages, years, location):
+    """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
+    t = df.loc[(location, sex)]
+    mu = pd.DataFrame(index=ages, columns=years, dtype=float)
+    s2 = pd.DataFrame(index=ages, columns=years, dtype=float)
+
+    for a in ages:
+        for y in years:
+            tt = t.query(
+                "age_start <= @a and @a < age_end and year_start <= @y and @y < year_end"
+            )
+            assert len(tt) == 1
+            mu.loc[a, y] = np.mean(tt.iloc[0])
+            s2.loc[a, y] = np.var(tt.iloc[0])
+
+    return mu, s2
+
+
+def at_param(name: str, ages, years, knot_val, method="constant") -> Callable:
+    """Create an age- and time-specific rate function for a DisMod model.
+
+    This function generates a 2d-interpolated rate function
+    with a TruncatedNormal prior.
+
+    It uses `searchsorted` as an efficient piecewise constant
+    interpolation method.
+
+    Parameters
+    ----------
+    name : str
+        The name of the rate parameter.
+    ages : array-like
+    years : array-like
+    knot_val : array-like with rows for ages and columns for years
+    method : str, interpolation method of "constant" or "linear"
+
+    Returns
+    -------
+    function
+        A function `f(a, t)` that takes array-like values age `a`
+        and time `t` as inputs and returns the interpolated rate value
+        specific to the given age and time.
+
+    Notes
+    -----
+    - For constant interpolation, the `searchsorted` method is set to
+      'scan', which is allegedly efficient for GPU computation.
+
+    """
+
+    if method == "constant":
+
+        def f(a: jnp.ndarray, t: jnp.ndarray) -> jnp.ndarray:
+            method = "scan"  # 'scan_unrolled' can be more performant on GPU at the
+            # expense of additional compile time
+            a_index = jnp.searchsorted(
+                jnp.asarray(ages[1:]),  # Start from ages[1]
+                # so that ages less than ages[1] map to
+                # index 0
+                jnp.asarray(a),
+                method=method,
+                side="right",
+            )
+            t_index = jnp.searchsorted(
+                jnp.asarray(years[1:]),  # Start from years[1]
+                # so that years less than years[1] map to
+                # index 0
+                jnp.asarray(t),
+                method=method,
+                side="right",
+            )
+            return knot_val[a_index, t_index]
+
+    elif method == "linear":
+        f = interpax.Interpolator2D(ages, years, knot_val, method="linear", extrap=True)
+    else:
+        assert 0, f'Method "{method}" unrecognized, should be "constant" or "linear"'
+    return f
+
+
+def data_model(name, f, df_data):  # FIXME: expose beta so it can be common across locations
+    if len(df_data) == 0:
+        return
+
+    ages = jnp.array(0.5 * (df_data.age_start + df_data.age_end))
+    years = jnp.array(0.5 * (df_data.year_start + df_data.year_end))
+    rate_obs_loc = jnp.array(df_data["mean"])
+    rate_obs_scale = jnp.array(df_data["standard_error"])
+
+    # refactor the following to use jax.vmap and to include population weights
+    rate_pred = jnp.zeros(len(df_data))
+    n_points = 5
+    for alpha in np.linspace(0, 1, n_points):
+        ages = jnp.array(alpha * df_data.age_start + (1 - alpha) * df_data.age_end)
+        rate_pred += f(ages, years)
+    rate_pred /= n_points
+
+    if len(df_data.filter(like="x_").columns) != 0:
+        # include fixed effects
+        X = jnp.array(df_data.filter(like="x_").fillna(0))
+        beta = numpyro.sample(
+            f"{name}_beta",
+            dist.Normal(loc=jnp.zeros(len(X[0])), scale=1.0),
+        )
+        rate_pred = jnp.exp(jnp.dot(X, beta)) * rate_pred
+
+    rate_obs = numpyro.sample(
+        f"{name}_obs", dist.Normal(loc=rate_pred, scale=rate_obs_scale), obs=rate_obs_loc
+    )
+    return rate_obs
+
+
+def at_param_w_data(param, ages, years, knot_val, df_data, method="constant"):
+    rate_function = at_param(param, ages, years, knot_val, method)
+    rate_data_obs = data_model(param, rate_function, df_data)
+    return rate_function
+
+
+def group_name(sex, location):
+    return f"{sex}_{location}".replace(" ", "_").lower()
+
+
+def single_location_model(
+    group,
+    sex,
+    location,
+    ages,
+    years,
+    knot_val_dict,
+    df_data,
+    include_consistency_constraints=True,
+):
+    group = group_name(sex, location)
+    i = at_param_w_data(
+        f"i_{group}", ages, years, knot_val_dict["i"], df_data[df_data.measure == "i"]
+    )
+    r = at_param_w_data(
+        f"r_{group}", ages, years, knot_val_dict["r"], df_data[df_data.measure == "r"]
+    )
+    ti = at_param_w_data(
+        f"ti_{group}", ages, years, knot_val_dict["ti"], df_data[df_data.measure == "ti"]
+    )
+    ts = at_param_w_data(
+        f"ts_{group}", ages, years, knot_val_dict["ts"], df_data[df_data.measure == "ts"]
+    )
+    tf = at_param_w_data(
+        f"tf_{group}", ages, years, knot_val_dict["tf"], df_data[df_data.measure == "tf"]
+    )
+    f = at_param_w_data(
+        f"f_{group}", ages, years, knot_val_dict["f"], df_data[df_data.measure == "f"]
+    )
+    m = at_param_w_data(
+        f"m_{group}", ages, years, knot_val_dict["m"], df_data[df_data.measure == "m"]
+    )
+
+    p = at_param_w_data(
+        f"p_{group}",
+        ages,
+        years,
+        knot_val_dict["p"],
+        df_data[df_data.measure == "p"],
+        method="constant",
+    )
+
+    tx = at_param_w_data(
+        f"tx_{group}",
+        ages,
+        years,
+        knot_val_dict["tx"],
+        df_data[df_data.measure == "tx"],
+        method="constant",
+    )
+
+    if include_consistency_constraints:
+        ode_model(group, p, tx, i, r, ti, ts, tf, f, m, sigma=0.01, ages=ages, years=years)
+    return dict(p=p, i=i, f=f, m=m, r=r, ti=ti, ts=ts, tf=tf)
+
+
+def ode_model(group, p, tx, i, r, ti, ts, tf, f, m, sigma, ages, years):
+    def dismod_f(t, y, args):
+        S, C, T = y
+        i, r, ti, ts, tf, f, m = args
+        return (
+            0 - m * S - i * S + r * C + ts * T,
+            0 - m * C - f * C + i * S - r * C - ti * C + tf * T,
+            0 - m * T - f * T + ti * C - ts * T - tf * T,
+        )
+
+    def ode_consistency_factor(at):
+        a, t = at
+        dt = 5
+        term = ODETerm(dismod_f)
+        solver = Dopri5()
+        saveat = SaveAt(t0=False, t1=True)
+
+        y0 = (1 - p(a, t), p(a, t) * (1 - tx(a, t)), p(a, t) * tx(a, t))
+        solution = diffeqsolve(
+            term,
+            solver,
+            t0=t,
+            t1=t + dt,
+            dt0=0.5,
+            y0=y0,
+            saveat=saveat,
+            args=[i(a, t), r(a, t), ti(a, t), ts(a, t), tf(a, t), f(a, t), m(a, t)],
+        )
+
+        S, C, T = solution.ys
+        difference = jnp.log((C + T) / (S + C + T)) - jnp.log(p(a + dt, t + dt))
+        difference += jnp.log(T / (T + C)) - jnp.log(tx(a + dt, t + dt))
+        return difference
+
+    # Vectorize the ode_consistency_factor function
+    ode_consistency_factors = jax.vmap(ode_consistency_factor)
+
+    # Create a mesh grid of ages and years
+    age_mesh, year_mesh = jnp.meshgrid(ages[:-1], years[:-1])
+    at_list = jnp.stack([age_mesh.ravel(), year_mesh.ravel()], axis=-1)
+
+    # Compute ODE errors for all age-time combinations at once
+    ode_errors = numpyro.deterministic(
+        f"ode_errors_{group}", ode_consistency_factors(at_list)
+    )
+
+    # Add a normal penalty for difference between solution and SC
+    log_pr = dist.Normal(0, sigma).log_prob(ode_errors).sum()
+    numpyro.factor(f"ode_consistency_factor_{group}", log_pr)
+
+
+class ConsistentModel:
+    def __init__(self, sex, ages, years):
+        self.sex = sex
+        self.ages = ages
+        self.years = years
+
+    def fit(self, df_data):
+        # expect this to take about 2 minutes to run
+        group = ""
+        ages, years = self.ages, self.years
+        location = ""
+        sex = self.sex
+
+        def model():
+            knot_val_dict = {}
+            for param in ["p", "tx", "i", "f", "m", "r", "ti", "tf", "ts"]:
+                knot_val_dict[param] = numpyro.sample(
+                    f"{param}_{group}",
+                    dist.TruncatedNormal(
+                        loc=jnp.zeros((len(ages), len(years))),
+                        scale=jnp.ones((len(ages), len(years))),
+                        low=0.0,
+                    ),
+                )
+            # TODO: consider moving knots of p to midpoints
+            rate_functions = single_location_model(
+                group,
+                sex,
+                location,
+                ages,
+                years,
+                knot_val_dict,
+                df_data,
+                include_consistency_constraints=True,
+            )
+
+        sampler = infer.MCMC(
+            infer.NUTS(
+                model,
+                init_strategy=numpyro.infer.init_to_value(
+                    values={
+                        f"p_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"tx_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"i_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"f_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"m_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"r_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"ti_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"ts_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"tf_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                    }
+                ),
+            ),
+            num_warmup=1_000,
+            num_samples=1_000,
+            num_chains=1,
+            progress_bar=True,
+        )
+
+        sampler.run(
+            jax.random.PRNGKey(0),
+        )
+        self.samples = sampler.get_samples()
+
+    def get_rate(self, param, year):
+        assert hasattr(self, "samples"), "Must run fit() first"
+        group = ""
+
+        rate_table = []
+        for i, a in enumerate(self.ages):
+            for j, t in enumerate(self.years):
+                if year != t:
+                    continue
+                rate = self.samples[f"{param}_{group}"][:, i, j]
+
+                row = dict(
+                    age_start=a,
+                    age_end=a + 5,
+                    year_start=t,
+                    year_end=t + 1,
+                    sex=self.sex,
+                )
+                for i, r_i in enumerate(rate):
+                    row[f"draw_{i}"] = float(r_i)
+                rate_table.append(row)
+        return pd.DataFrame(rate_table).set_index(
+            ["sex", "age_start", "age_end", "year_start", "year_end"]
+        )
+
+
+def generate_consistent_rates(art: Artifact, location: str):
+    """Generates consistent rates for sim
+
+    Parameters
+    ----------
+    art
+        The artifact to read from and write to.
+    location
+        The location associated with the data to load and the artifact to
+        write to.
+    years
+        The years to load data for.
+
+    """
+    # TODO: check if the consistent rates are already in the artifact, and if so, skip rest of this function
+    ages = np.arange(5, 96, 5)
+    years = np.arange(2025, 2051, 5)
+    sexes = ["Male", "Female"]
+    key = {
+        "i": "cause.opioid_use_disorders.incidence_rate",
+        "p": "cause.alzheimers.prevalence",
+        "f": "cause.opioid_use_disorders.excess_mortality_rate",
+        "m_all": "cause.all_causes.cause_specific_mortality_rate",
+        "csmr_with": "cause.opioid_use_disorders.cause_specific_mortality_rate",
+        "pop": "population.structure",
+    }
+
+    def etl_data(sex):
+        df_data = pd.concat(
+            [
+                transform_to_data("p", art.load(key["p"]), sex, ages, [2023]),
+                # transform_to_data("i", art.load(key["i"]), sex, ages, [2021]),
+                # transform_to_data("f", art.load(key["f"]), sex, ages, [2021]),
+                # transform_to_data(
+                #     "m",
+                #     art.load(key["m_all"]) - art.load(key["csmr_with"]),
+                #     sex,
+                #     ages,
+                #     [2021],
+                # ),
+                # transform_to_data("ti", utils.generate_constant_data(0.0), sex, ages, [2021]), 
+                # transform_to_data("ts", utils.generate_constant_data(0.0), sex, ages, [2021]), 
+                # transform_to_data("tf", utils.generate_constant_data(1.0), sex, ages, [2021]), 
+                # transform_to_data("tx", utils.generate_constant_data(0.0), sex, ages, [2021]), 
+            ]
+        )
+        return df_data
+
+    def get_rates(model_dict, rate_type, year):
+        df_out = []
+        for model in model_dict.values():
+            df_out.append(model.get_rate(rate_type, year))
+        df_out = pd.concat(df_out)
+        return df_out
+
+    # fit model separately for Male and Female
+    m = {}
+    for sex in sexes:
+        breakpoint()
+
+        m[sex] = ConsistentModel(sex, ages, years)
+        m[sex].fit(etl_data(sex))
+
+    # store consistent rates in artifact
+    for rate_type in ["i", "p_bbbm", "p_mci", "p_ad"]:
+        # generate data for k
+        df_out = get_rates(m, rate_type, 2020)
+        # store generated data in artifact
+        rate_name = key[rate_type]
+        rate_name = rate_name.replace("alzheimers", "ad_consistent")
+        write_or_replace(art, rate_name, df_out)
+
+
+def write_or_replace(art, key, data):
+    if key in art.keys:
+        art.replace(key, data)
+    else:
+        art.write(key, data)
+
+
+if __name__ == "__main__":
+    location = "United States of America"
+    art = Artifact("united_states_of_america.hdf")
+    generate_consistent_rates(art, location)

--- a/src/vivarium_csu_alzheimers/data/consistent_rates.py
+++ b/src/vivarium_csu_alzheimers/data/consistent_rates.py
@@ -15,37 +15,275 @@ from numpyro import infer
 from vivarium.framework.artifact import Artifact
 
 from vivarium_csu_alzheimers.constants.data_values import BBBM_AVG_DURATION, MCI_AVG_DURATION
-def transform_to_data(param: str, df_in: pd.DataFrame, sex: str, ages: Iterable[int], years: Iterable[int]) -> pd.DataFrame:
-    """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
-    t = df_in.loc[sex]
-    results = []  # fill with rows of data, then convert to a dataframe
 
-    for a in ages:
-        for y in years:
-            # Note: age_end and year_end here are meta fields used only for midpoints
-            # computation downstream; they do not affect which rows are selected from
-            # the artifact (selection is done via the query below).
-            row = {
-                "age_start": a,
-                "age_end": a,
-                "year_start": y,
-                "year_end": y,
-                "sex": sex,
-                "measure": param,
-            }
-            tt = t.query(
-                "age_start <= @a and @a < age_end and year_start <= @y and @y < year_end"
+def generate_consistent_rates(art: Artifact):
+    """Generates consistent rates for sim of BBBM-AD
+
+    Parameters
+    ----------
+    art
+        The artifact to read from and write to.
+
+    """
+    load_key = {
+        "p_dementia": "cause.alzheimers.prevalence",
+        "i_dementia": "cause.alzheimers.population_incidence_rate",
+        "f": "cause.alzheimers_disease_and_other_dementias.excess_mortality_rate",
+        "m_all": "cause.all_causes.cause_specific_mortality_rate",
+    }
+    
+    save_key = {
+        "h_S_to_BBBM": "cause.alzheimers_consistent.population_incidence_any",
+        "p": "cause.alzheimers_consistent.prevalence_any",
+        # "p_dementia": "cause.alzheimers_consistent.prevalence_dementia",  # not in samples
+        "i": "cause.alzheimers_consistent.population_incidence_dementia",
+        "f": "cause.alzheimers_consistent.excess_mortality_rate",
+        "delta_BBBM": "cause.alzheimers_consistent.bbbm_conditional_prevalence",
+        "delta_MCI": "cause.alzheimers_consistent.mci_conditional_prevalence",
+        "ode_errors": "cause.alzheimers_consistent.ode_errors",
+    }
+
+    # fit model separately for Male and Female
+    model_dict = {}
+    ages = np.arange(30, 101, 5)
+    for sex in ["Male", "Female"]:
+        # ETL the data
+        df_data = pd.concat(
+            [
+                transform_to_data("p_dementia", art.load(load_key["p_dementia"]), sex, ages, [2023]),
+                transform_to_data("i_dementia", art.load(load_key["i_dementia"]), sex, ages, [2023]),
+                transform_to_data("f", art.load(load_key["f"]), sex, ages, [2021]),
+                transform_to_data("m_all", art.load(load_key["m_all"]), sex, ages, [2025]),
+            ]
+        )
+
+        # create and fit the model
+        model_dict[sex] = BBBM_AD_Model(ages, [2025], sex)
+        model_dict[sex].fit(ages, df_data)
+
+    # store consistent rates in artifact
+    for rate_type in save_key.keys():
+        # generate data for this rate_type
+        df_out = []
+        for model in model_dict.values():
+            df_out.append(model.get_rate(rate_type, 2025))
+        df_out = pd.concat(df_out)
+
+        # store generated data in artifact
+        rate_name = save_key[rate_type]
+        write_or_replace(art, rate_name, df_out)
+
+
+class BBBM_AD_Model:
+    """Class to create and fit a consistent model of BBBM-AD using MCMC with Numpyro
+    """
+    def __init__(self, ages, years, sex):
+        self.ages = ages
+        self.years = years
+        self.sex = sex
+
+
+    def fit(self, ages, df_data):
+
+        # copy this into shorter variable names for convenience
+        years = self.years
+        ages = self.ages
+
+        def numpyro_model():
+            knot_val_dict = {}
+            for param in ["p", "delta_BBBM", "delta_MCI", "h_S_to_BBBM", "i", "f", "m"]:
+                knot_val_dict[param] = numpyro.sample(
+                    f"{param}",
+                    dist.TruncatedNormal(
+                        loc=jnp.zeros((len(ages), len(years))),
+                        scale=jnp.ones((len(ages), len(years))),
+                        low=0.0,
+                        high=1.0,
+                    ),
+                )
+
+            p = at_param(
+                f"p",
+                ages,
+                years,
+                knot_val_dict["p"],
             )
-            assert len(tt) == 1
-            row["mean"] = np.mean(tt.iloc[0])
-            row["standard_error"] = (
-                np.std(tt.iloc[0])
-                + 1e-8  # small epsilon to avoid zero standard errors
+            delta_BBBM = at_param(
+                f"delta_BBBM",
+                ages,
+                years,
+                knot_val_dict["delta_BBBM"],
+            )
+            delta_MCI = at_param(
+                f"delta_MCI",
+                ages,
+                years,
+                knot_val_dict["delta_MCI"],
             )
 
-            results.append(row)
+            def p_dementia(a, t):
+                return p(a, t) * (1 - delta_BBBM(a, t) - delta_MCI(a, t))
 
-    return pd.DataFrame(results)
+            data_model("p_dementia", p_dementia, df_data.query("measure == 'p_dementia'"))
+
+            h_S_to_BBBM = at_param(
+                f"h_S_to_BBBM",
+                ages,
+                years,
+                knot_val_dict["h_S_to_BBBM"],
+            )
+
+            i = at_param(
+                f"i", ages, years, knot_val_dict["i"]
+            )
+            data_model("i", i, df_data.query('measure == "i_dementia"'))
+            
+            f = at_param(
+                f"f", ages, years, knot_val_dict["f"],
+            )
+            data_model('f', f, df_data.query('measure == "f"'))
+
+            m = at_param(
+                f"m", ages, years, knot_val_dict["m"]
+            )
+            
+            def m_all(a, t):
+                # Population all-cause mortality: m * (1 - p_dementia) + (m + f) * p_dementia = m + f * p_dementia
+                return m(a, t) + f(a, t) * p_dementia(a, t)
+            data_model("m_all", m_all, df_data.query('measure == "m_all"'))
+
+            include_consistency_constraints = True
+            if include_consistency_constraints:
+                sigma=0.005
+
+                def odf_function(t, y, args):
+                    S, BBBM, MCI, D, new_D = y
+                    h_S_to_BBBM, h_BBBM_to_MCI, h_MCI_to_dementia, f, m = args
+                    return (
+                        0 - m * S                                                       - h_S_to_BBBM * S,
+                        0 - m * BBBM                             - h_BBBM_to_MCI * BBBM + h_S_to_BBBM * S,
+                        0 - m * MCI    - h_MCI_to_dementia * MCI + h_BBBM_to_MCI * BBBM,
+                        0 - (m+f) * D  + h_MCI_to_dementia * MCI,
+                        h_MCI_to_dementia * MCI,
+                    )
+
+                def ode_consistency_factor(at):
+                    h_BBBM_to_MCI = 1/BBBM_AVG_DURATION
+                    h_MCI_to_dementia = 1/MCI_AVG_DURATION
+                    
+                    a, t = at
+                    dt = 5
+                    term = ODETerm(odf_function)
+                    solver = Dopri5()
+                    saveat = SaveAt(t0=False, t1=True)
+
+                    solution = diffeqsolve(
+                        term,
+                        solver,
+                        t0=t,
+                        t1=t + dt,
+                        dt0=0.5,
+                        y0=(
+                            1 - p(a, t),
+                            p(a, t) * delta_BBBM(a, t), 
+                            p(a, t) * delta_MCI(a, t),
+                            p(a, t) * (1 - delta_BBBM(a, t) - delta_MCI(a, t)),
+                            0
+                        ),
+                        saveat=saveat,
+                        args=[
+                            h_S_to_BBBM(a, t),
+                            h_BBBM_to_MCI,
+                            h_MCI_to_dementia,
+                            f(a, t),
+                            m(a, t)
+                        ],
+                    )
+
+                    S, BBBM, MCI, D, new_D = solution.ys
+                    # Numerical stability for log terms
+                    eps = 1e-12
+                    denom_alive = S + BBBM + MCI + D
+                    denom_noS = BBBM + MCI + D
+                    # Clip to avoid log(0)
+                    r_bbbm = jnp.clip(BBBM / (denom_noS + eps), eps)
+                    r_mci = jnp.clip(MCI / (denom_noS + eps), eps)
+                    r_prev = jnp.clip(D / (denom_alive + eps), eps)
+                    r_inc = jnp.clip(new_D / (dt * (denom_alive + eps)), eps)
+
+                    sq_difference = 0.0
+                    sq_difference += (jnp.log(r_bbbm) - jnp.log(jnp.clip(delta_BBBM(a + dt, t + dt), eps)))**2
+                    sq_difference += (jnp.log(r_mci) - jnp.log(jnp.clip(delta_MCI(a + dt, t + dt), eps)))**2
+                    sq_difference += (jnp.log(r_prev) - jnp.log(jnp.clip(p_dementia(a + dt, t + dt), eps)))**2
+                    sq_difference += (jnp.log(r_inc) - jnp.log(jnp.clip(i(a + dt/2, t + dt/2), eps)))**2
+                    return jnp.sqrt(sq_difference)
+
+                # Vectorize the ode_consistency_factor function
+                ode_consistency_factors = jax.vmap(ode_consistency_factor)
+
+                # Create a mesh grid of ages and years
+                age_mesh, year_mesh = jnp.meshgrid(jnp.array(ages),
+                                                   jnp.array(years))
+                at_list = jnp.stack([age_mesh.ravel(), year_mesh.ravel()], axis=-1)
+
+                # Compute ODE errors for all age-time combinations at once
+                ode_errors = numpyro.deterministic(
+                    f"ode_errors", ode_consistency_factors(at_list)
+                )
+
+                # Add a normal penalty for difference between solution and params
+                log_pr = dist.Normal(0, sigma).log_prob(ode_errors).sum()
+                numpyro.factor(f"ode_consistency_factor", log_pr)
+
+        sampler = infer.MCMC(
+            infer.NUTS(
+                numpyro_model,
+                init_strategy=numpyro.infer.init_to_value(
+                    values={
+                        f"p": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"delta_BBBM": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"delta_MCI": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"h_S_to_BBBM": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"i": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"f": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"m": jnp.ones([len(ages), len(years)]) * 0.05,
+                    }
+                ),
+            ),
+            num_warmup=500,
+            num_samples=500,
+            num_chains=1,
+            progress_bar=True,
+        )
+
+        sampler.run(
+            jax.random.PRNGKey(0),
+        )
+        self.samples = sampler.get_samples()
+
+    def get_rate(self, param, year):
+        assert hasattr(self, "samples"), "Must run fit() first"
+
+        rate_table = []
+        for i, a in enumerate(self.ages):
+            for j, t in enumerate(self.years):
+                if year != t:
+                    continue
+                rate = self.samples[param][:, i, j]
+
+                row = dict(
+                    age_start=a,
+                    age_end=a + 5,
+                    year_start=t,
+                    year_end=t + 1,
+                    sex=self.sex,
+                )
+                for i, r_i in enumerate(rate):
+                    row[f"draw_{i}"] = float(r_i)
+                rate_table.append(row)
+        return pd.DataFrame(rate_table).set_index(
+            ["sex", "age_start", "age_end", "year_start", "year_end"]
+        )
 
 
 def at_param(name: str, ages, years, knot_val) -> Callable:
@@ -117,294 +355,37 @@ def data_model(name: str, f: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray], 
     return rate_obs
 
 
-def ode_model(group: str,
-              p: Callable, i: Callable, delta_BBBM: Callable, delta_MCI: Callable,
-              h_S_to_BBBM: Callable, p_dementia: Callable, f: Callable, m: Callable,
-              sigma: float, ages, years):
-    def dismod_f(t, y, args):
-        S, BBBM, MCI, D, new_D = y
-        h_S_to_BBBM, h_BBBM_to_MCI, h_MCI_to_dementia, f, m = args
-        return (
-            0 - m * S                                                       - h_S_to_BBBM * S,
-            0 - m * BBBM                             - h_BBBM_to_MCI * BBBM + h_S_to_BBBM * S,
-            0 - m * MCI    - h_MCI_to_dementia * MCI + h_BBBM_to_MCI * BBBM,
-            0 - (m+f) * D  + h_MCI_to_dementia * MCI,
-            h_MCI_to_dementia * MCI,
-        )
+def transform_to_data(param: str, df_in: pd.DataFrame, sex: str, ages: Iterable[int], years: Iterable[int]) -> pd.DataFrame:
+    """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
+    t = df_in.loc[sex]
+    results = []  # fill with rows of data, then convert to a dataframe
 
-    def ode_consistency_factor(at):
-        h_BBBM_to_MCI = 1/BBBM_AVG_DURATION
-        h_MCI_to_dementia = 1/MCI_AVG_DURATION
-        
-        a, t = at
-        dt = 5
-        term = ODETerm(dismod_f)
-        solver = Dopri5()
-        saveat = SaveAt(t0=False, t1=True)
-
-        solution = diffeqsolve(
-            term,
-            solver,
-            t0=t,
-            t1=t + dt,
-            dt0=0.5,
-            y0=(
-                1 - p(a, t),
-                p(a, t) * delta_BBBM(a, t), 
-                p(a, t) * delta_MCI(a, t),
-                p(a, t) * (1 - delta_BBBM(a, t) - delta_MCI(a, t)),
-                0
-            ),
-            saveat=saveat,
-            args=[
-                h_S_to_BBBM(a, t),
-                h_BBBM_to_MCI,
-                h_MCI_to_dementia,
-                f(a, t),
-                m(a, t)
-            ],
-        )
-
-        S, BBBM, MCI, D, new_D = solution.ys
-        # Numerical stability for log terms
-        eps = 1e-12
-        denom_alive = S + BBBM + MCI + D
-        denom_noS = BBBM + MCI + D
-        # Clip to avoid log(0)
-        r_bbbm = jnp.clip(BBBM / (denom_noS + eps), eps)
-        r_mci = jnp.clip(MCI / (denom_noS + eps), eps)
-        r_prev = jnp.clip(D / (denom_alive + eps), eps)
-        r_inc = jnp.clip(new_D / (dt * (denom_alive + eps)), eps)
-
-        sq_difference = 0.0
-        sq_difference += (jnp.log(r_bbbm) - jnp.log(jnp.clip(delta_BBBM(a + dt, t + dt), eps)))**2
-        sq_difference += (jnp.log(r_mci) - jnp.log(jnp.clip(delta_MCI(a + dt, t + dt), eps)))**2
-        sq_difference += (jnp.log(r_prev) - jnp.log(jnp.clip(p_dementia(a + dt, t + dt), eps)))**2
-        sq_difference += (jnp.log(r_inc) - jnp.log(jnp.clip(i(a + dt/2, t + dt/2), eps)))**2
-        return jnp.sqrt(sq_difference)
-
-    # Vectorize the ode_consistency_factor function
-    ode_consistency_factors = jax.vmap(ode_consistency_factor)
-
-    # Create a mesh grid of ages and years
-    age_mesh, year_mesh = jnp.meshgrid(jnp.array(ages[:-1]),
-                                       jnp.array(years[:-1]))
-    at_list = jnp.stack([age_mesh.ravel(), year_mesh.ravel()], axis=-1)
-
-    # Compute ODE errors for all age-time combinations at once
-    ode_errors = numpyro.deterministic(
-        f"ode_errors_{group}", ode_consistency_factors(at_list)
-    )
-
-    # Add a normal penalty for difference between solution and params
-    log_pr = dist.Normal(0, sigma).log_prob(ode_errors).sum()
-    numpyro.factor(f"ode_consistency_factor_{group}", log_pr)
-
-
-class ConsistentModel:
-    def __init__(self, sex, ages, years):
-        self.sex = sex
-        self.ages = ages
-        self.years = years
-
-    def fit(self, df_data):
-        group = ""
-        ages, years = self.ages, self.years
-        location = ""
-        sex = self.sex
-
-        def model():
-            knot_val_dict = {}
-            for param in ["p", "delta_BBBM", "delta_MCI", "h_S_to_BBBM", "i", "f", "m"]:
-                knot_val_dict[param] = numpyro.sample(
-                    f"{param}_{group}",
-                    dist.TruncatedNormal(
-                        loc=jnp.zeros((len(ages), len(years))),
-                        scale=jnp.ones((len(ages), len(years))),
-                        low=0.0,
-                        high=1.0,
-                    ),
-                )
-
-            p = at_param(
-                f"p",
-                ages,
-                years,
-                knot_val_dict["p"],
+    for a in ages:
+        for y in years:
+            # Note: age_end and year_end here are meta fields used only for midpoints
+            # computation downstream; they do not affect which rows are selected from
+            # the artifact (selection is done via the query below).
+            row = {
+                "age_start": a,
+                "age_end": a,
+                "year_start": y,
+                "year_end": y,
+                "sex": sex,
+                "measure": param,
+            }
+            tt = t.query(
+                "age_start <= @a and @a < age_end and year_start <= @y and @y < year_end"
             )
-            delta_BBBM = at_param(
-                f"delta_BBBM",
-                ages,
-                years,
-                knot_val_dict["delta_BBBM"],
-            )
-            delta_MCI = at_param(
-                f"delta_MCI",
-                ages,
-                years,
-                knot_val_dict["delta_MCI"],
+            assert len(tt) == 1
+            row["mean"] = np.mean(tt.iloc[0])
+            row["standard_error"] = (
+                np.std(tt.iloc[0])
+                + 1e-8  # small epsilon to avoid zero standard errors
             )
 
-            def p_dementia(a, t):
-                return p(a, t) * (1 - delta_BBBM(a, t) - delta_MCI(a, t))
+            results.append(row)
 
-            data_model("p_dementia", p_dementia, df_data.query("measure == 'p_dementia'"))
-
-            h_S_to_BBBM = at_param(
-                f"h_S_to_BBBM",
-                ages,
-                years,
-                knot_val_dict["h_S_to_BBBM"],
-            )
-
-            i = at_param(
-                f"i", ages, years, knot_val_dict["i"]
-            )
-            data_model("i", i, df_data.query('measure == "i_dementia"'))
-            
-            f = at_param(
-                f"f", ages, years, knot_val_dict["f"],
-            )
-            data_model('f', f, df_data.query('measure == "f"'))
-
-            m = at_param(
-                f"m", ages, years, knot_val_dict["m"]
-            )
-            
-            def m_all(a, t):
-                # Population all-cause mortality: m * (1 - p_dementia) + (m + f) * p_dementia = m + f * p_dementia
-                return m(a, t) + f(a, t) * p_dementia(a, t)
-            data_model("m_all", m_all, df_data.query('measure == "m_all"'))
-
-            include_consistency_constraints = True
-            if include_consistency_constraints:
-                ode_model(group, 
-                          p, i, delta_BBBM, delta_MCI, h_S_to_BBBM, p_dementia, f, m,
-                          sigma=0.01, ages=ages, years=[2025, 2100])
-
-
-        sampler = infer.MCMC(
-            infer.NUTS(
-                model,
-                init_strategy=numpyro.infer.init_to_value(
-                    values={
-                        f"p_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                        f"delta_BBBM_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                        f"delta_MCI_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                        f"h_S_to_BBBM_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                        f"i_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                        f"f_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                        f"m_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
-                    }
-                ),
-            ),
-            num_warmup=500,
-            num_samples=500,
-            num_chains=1,
-            progress_bar=True,
-        )
-
-        sampler.run(
-            jax.random.PRNGKey(0),
-        )
-        self.samples = sampler.get_samples()
-
-    def get_rate(self, param, year):
-        assert hasattr(self, "samples"), "Must run fit() first"
-        group = ""
-
-        rate_table = []
-        for i, a in enumerate(self.ages):
-            for j, t in enumerate(self.years):
-                if year != t:
-                    continue
-                rate = self.samples[f"{param}_{group}"][:, i, j]
-
-                row = dict(
-                    age_start=a,
-                    age_end=a + 5,
-                    year_start=t,
-                    year_end=t + 1,
-                    sex=self.sex,
-                )
-                for i, r_i in enumerate(rate):
-                    row[f"draw_{i}"] = float(r_i)
-                rate_table.append(row)
-        return pd.DataFrame(rate_table).set_index(
-            ["sex", "age_start", "age_end", "year_start", "year_end"]
-        )
-
-
-def generate_consistent_rates(art: Artifact, location: str):
-    """Generates consistent rates for sim
-
-    Parameters
-    ----------
-    art
-        The artifact to read from and write to.
-    location
-        The location associated with the data to load and the artifact to
-        write to.
-    years
-        The years to load data for.
-
-    """
-    # TODO: check if the consistent rates are already in the artifact, and if so, skip rest of this function
-    ages = np.arange(30, 101, 5)
-    years = [2025]
-    sexes = ["Male", "Female"]
-    load_key = {
-        "p_dementia": "cause.alzheimers.prevalence",
-        "i_dementia": "cause.alzheimers.population_incidence_rate",
-        "f": "cause.alzheimers_disease_and_other_dementias.excess_mortality_rate",
-        "m_all": "cause.all_causes.cause_specific_mortality_rate",
-    }
-    save_key = {
-        "h_S_to_BBBM": "cause.alzheimers_consistent.population_incidence_any",
-        "p": "cause.alzheimers_consistent.prevalence_any",
-        # "p_dementia": "cause.alzheimers_consistent.prevalence_dementia",  # not in samples
-        "i": "cause.alzheimers_consistent.population_incidence_dementia",
-        "f": "cause.alzheimers_consistent.excess_mortality_rate",
-        "delta_BBBM": "cause.alzheimers_consistent.bbbm_conditional_prevalence",
-        "delta_MCI": "cause.alzheimers_consistent.mci_conditional_prevalence",
-        "ode_errors": "cause.alzheimers_consistent.ode_errors",
-    }
-
-    def etl_data(sex):
-        df_data = pd.concat(
-            [
-                transform_to_data("p_dementia", art.load(load_key["p_dementia"]), sex, ages, [2023]),
-                transform_to_data("i_dementia", art.load(load_key["i_dementia"]), sex, ages, [2023]),
-                transform_to_data("f", art.load(load_key["f"]), sex, ages, [2021]),
-                transform_to_data("m_all", art.load(load_key["m_all"]), sex, ages, years),
-            ]
-        )
-
-        for key in load_key.keys():
-            assert key in set(df_data.measure)
-
-        return df_data
-
-    def get_rates(model_dict, rate_type, year):
-        df_out = []
-        for model in model_dict.values():
-            df_out.append(model.get_rate(rate_type, year))
-        df_out = pd.concat(df_out)
-        return df_out
-
-    # fit model separately for Male and Female
-    m = {}
-    for sex in sexes:
-        m[sex] = ConsistentModel(sex, ages, years)
-        m[sex].fit(etl_data(sex))
-
-    # store consistent rates in artifact
-    for rate_type in save_key.keys():
-        # generate data for this rate_type
-        df_out = get_rates(m, rate_type, 2025)
-        # store generated data in artifact
-        rate_name = save_key[rate_type]
-        write_or_replace(art, rate_name, df_out)
+    return pd.DataFrame(results)
 
 
 def write_or_replace(art: Artifact, key: str, data: pd.DataFrame):
@@ -416,6 +397,5 @@ def write_or_replace(art: Artifact, key: str, data: pd.DataFrame):
 
 
 if __name__ == "__main__":
-    location = "United States of America"
     art = Artifact("united_states_of_america.hdf")
-    generate_consistent_rates(art, location)
+    generate_consistent_rates(art)

--- a/src/vivarium_csu_alzheimers/data/consistent_rates.py
+++ b/src/vivarium_csu_alzheimers/data/consistent_rates.py
@@ -298,9 +298,11 @@ class ConsistentModel:
                 f"f", ages, years, knot_val_dict["f"],
             )
             data_model('f', f, df_data.query('measure == "f"'))
+
             m = at_param(
                 f"m", ages, years, knot_val_dict["m"]
             )
+            
             def m_all(a, t):
                 # Population all-cause mortality: m * (1 - p_dementia) + (m + f) * p_dementia = m + f * p_dementia
                 return m(a, t) + f(a, t) * p_dementia(a, t)
@@ -390,10 +392,10 @@ def generate_consistent_rates(art: Artifact, location: str):
         "m_all": "cause.all_causes.cause_specific_mortality_rate",
     }
     save_key = {
-        "h_S_to_BBBM": "cause.alzheimers_consistent.population_incidence_rate",
+        "h_S_to_BBBM": "cause.alzheimers_consistent.population_incidence_any",
         "p": "cause.alzheimers_consistent.prevalence_any",
         # "p_dementia": "cause.alzheimers_consistent.prevalence_dementia",  # not in samples
-        "i": "cause.alzheimers_consistent.incidence",
+        "i": "cause.alzheimers_consistent.population_incidence_dementia",
         "f": "cause.alzheimers_consistent.excess_mortality_rate",
         "delta_BBBM": "cause.alzheimers_consistent.bbbm_conditional_prevalence",
         "delta_MCI": "cause.alzheimers_consistent.mci_conditional_prevalence",


### PR DESCRIPTION
## Title: Use MCMC to find consistent rates for the BBBM-AD model
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: data artifact
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes
This uses an approach inspired by DisMod to find internally consistent rates for the transitions in the BBBM-AD model.

### Verification and Testing

I put a notebook comparing the consistent artifact values to the current (model 5.0) artifact in the vivarium_research_alzheimers repo [here](https://github.com/ihmeuw/vivarium_research_alzheimers/blob/main/generate_and_test_consistent_rates.ipynb).
